### PR TITLE
Fix off-by-one error

### DIFF
--- a/acme-year.cabal
+++ b/acme-year.cabal
@@ -1,5 +1,5 @@
 name:                acme-year
-version:             2015
+version:             2016
 synopsis:            Get the current year
 -- description:
 license:             PublicDomain


### PR DESCRIPTION
I noticed a small bug in one of the main components of the library, and managed to fix it. Tests are green, but seem a little sparse. Maybe we should see what `hpc` has to say.
